### PR TITLE
Replace deprecated code style

### DIFF
--- a/Formula/azdata-cli.rb
+++ b/Formula/azdata-cli.rb
@@ -12,8 +12,7 @@ class AzdataCli < Formula
 
   bottle do
     root_url "https://github.com/microsoft/homebrew-azdata-cli-release/releases/download/20.3.4"
-    cellar :any
-    sha256 "8c60030cf12c73b8de3bb69bca22bef6d2717d0d2125826b19274ca56eb95245" => :catalina
+    sha256 cellar: :any, catalina: "8c60030cf12c73b8de3bb69bca22bef6d2717d0d2125826b19274ca56eb95245"
   end
 
   depends_on "freetds"


### PR DESCRIPTION
```console
Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the microsoft/azdata-cli-release tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/microsoft/homebrew-azdata-cli-release/Formula/azdata-cli.rb:15

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the microsoft/azdata-cli-release tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/microsoft/homebrew-azdata-cli-release/Formula/azdata-cli.rb:16
```